### PR TITLE
Add UAS-themed login with particle background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,29 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.particle {
+  position: absolute;
+  bottom: -10px;
+  background-color: rgba(201, 162, 39, 0.8); /* UAS gold */
+  border-radius: 9999px;
+  opacity: 0.7;
+  pointer-events: none;
+  animation-name: rise;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+@keyframes rise {
+  from {
+    transform: translateY(0) scale(1);
+    opacity: 0;
+  }
+  50% {
+    opacity: 0.8;
+  }
+  to {
+    transform: translateY(-100vh) scale(0.5);
+    opacity: 0;
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { auth } from "../../src/lib/firebase";
+import Particles from "../../components/particles";
 
 export default function LoginPage() {
   const handleLogin = async () => {
@@ -9,13 +10,19 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <button
-        onClick={handleLogin}
-        className="rounded bg-uas-dark-green px-4 py-2 text-white"
-      >
-        Ingresar con Google
-      </button>
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-uas-dark-green via-uas-indigo to-uas-dark-green">
+      <Particles />
+      <div className="relative z-10 rounded-xl bg-white/10 p-8 backdrop-blur-md">
+        <h1 className="mb-4 text-center text-2xl font-bold text-uas-white">
+          Iniciar sesión
+        </h1>
+        <button
+          onClick={handleLogin}
+          className="w-full rounded bg-uas-gold px-4 py-2 font-semibold text-uas-dark-green transition-colors hover:bg-uas-gold/90"
+        >
+          Ingresar con Google
+        </button>
+      </div>
     </main>
   );
 }

--- a/components/particles.tsx
+++ b/components/particles.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useMemo } from "react";
+
+export default function Particles() {
+  const particles = useMemo(
+    () =>
+      Array.from({ length: 40 }, () => ({
+        left: Math.random() * 100,
+        size: Math.random() * 4 + 2,
+        delay: Math.random() * 5,
+        duration: Math.random() * 15 + 5,
+      })),
+    []
+  );
+
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      {particles.map((p, i) => (
+        <span
+          key={i}
+          className="particle"
+          style={{
+            left: `${p.left}%`,
+            width: `${p.size}px`,
+            height: `${p.size}px`,
+            animationDelay: `${p.delay}s`,
+            animationDuration: `${p.duration}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- redesign login page with UAS color scheme, translucent card, and particle effects
- add reusable particle background component
- add particle animation styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68af4c403130832bbf49d20972bcda65