### PR TITLE
feat: enforce user validation via Firestore and protect dashboard

### DIFF
--- a/app/(protected)/dashboard/layout.tsx
+++ b/app/(protected)/dashboard/layout.tsx
@@ -1,0 +1,34 @@
+"use client";
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../../../src/context/AuthContext";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { user, perfil, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading) {
+      if (!user || !perfil?.activo) {
+        router.replace(
+          "/login?message=No%20autorizado,%20contacta%20al%20administrador"
+        );
+      }
+    }
+  }, [user, perfil, loading, router]);
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const session = request.cookies.get("session");
+  if (!session) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*"],
+};

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import {
+  GoogleAuthProvider,
+  User,
+  onAuthStateChanged as firebaseOnAuthStateChanged,
+  signInWithPopup,
+  signOut,
+} from "firebase/auth";
+import { doc, getDoc } from "firebase/firestore";
+import { auth, db } from "../lib/firebase";
+
+type Perfil = {
+  rol: string;
+  facultad: string;
+  activo: boolean;
+};
+
+type AuthContextProps = {
+  user: User | null;
+  perfil: Perfil | null;
+  loading: boolean;
+  signInGoogle: () => Promise<void>;
+  signOutApp: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextProps>(null as any);
+
+export const useAuth = () => useContext(AuthContext);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [perfil, setPerfil] = useState<Perfil | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const clearSession = () => {
+    setUser(null);
+    setPerfil(null);
+    document.cookie = "session=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  };
+
+  const verifyUser = async (u: User) => {
+    if (!u.email) {
+      await signOut(auth);
+      clearSession();
+      alert("No autorizado, contacta al administrador");
+      return;
+    }
+    const ref = doc(db, "Usuarios", u.email);
+    const snap = await getDoc(ref);
+    if (!snap.exists() || !snap.data().activo) {
+      await signOut(auth);
+      clearSession();
+      alert("No autorizado, contacta al administrador");
+      return;
+    }
+    const data = snap.data() as Perfil;
+    setUser(u);
+    setPerfil(data);
+    document.cookie = `session=${u.email}; path=/`;
+  };
+
+  useEffect(() => {
+    const unsubscribe = firebaseOnAuthStateChanged(auth, async (u) => {
+      if (u) {
+        await verifyUser(u);
+      } else {
+        clearSession();
+      }
+      setLoading(false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const signInGoogle = async () => {
+    const provider = new GoogleAuthProvider();
+    await signInWithPopup(auth, provider);
+  };
+
+  const signOutApp = async () => {
+    await signOut(auth);
+    clearSession();
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{ user, perfil, loading, signInGoogle, signOutApp }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add AuthContext with Firestore profile check and Google sign-in helpers
- protect dashboard layout using AuthContext and redirect unauthorized users
- add middleware requiring a session cookie for dashboard routes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68af71944388832bab296616eac171fb