### PR TITLE
feat: add Firestore models and services

### DIFF
--- a/src/services/empresas.ts
+++ b/src/services/empresas.ts
@@ -1,0 +1,124 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit as limitQuery,
+  startAfter,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  serverTimestamp,
+  Timestamp,
+  QueryConstraint,
+} from "firebase/firestore";
+import { db } from "../lib/firebase";
+import type { Empresa, FiltrosEmpresas, Usuario } from "../types";
+
+const COL = "Empresas";
+
+const assertAdminOrMod = (actor: Usuario) => {
+  if (actor.rol !== "Administrador" && actor.rol !== "Moderador") {
+    throw new Error("No autorizado");
+  }
+};
+
+const assertAdmin = (actor: Usuario) => {
+  if (actor.rol !== "Administrador") {
+    throw new Error("No autorizado");
+  }
+};
+
+export async function listEmpresas(
+  f: FiltrosEmpresas & { limit?: number; startAfterId?: string }
+): Promise<{ items: Empresa[]; nextPageCursor?: string }> {
+  const constraints: QueryConstraint[] = [];
+  if (f.facultad) constraints.push(where("facultad", "==", f.facultad));
+  if (f.rangoAlta?.desde)
+    constraints.push(where("fechaAlta", ">=", f.rangoAlta.desde));
+  if (f.rangoAlta?.hasta)
+    constraints.push(where("fechaAlta", "<=", f.rangoAlta.hasta));
+
+  let orderField: string = "fechaAlta";
+  let orderDir: "asc" | "desc" = "desc";
+
+  if (f.proximasVencerDias !== undefined) {
+    const now = Timestamp.now();
+    const future = Timestamp.fromMillis(
+      now.toMillis() + f.proximasVencerDias * 86400000
+    );
+    constraints.push(where("fechaVencimiento", ">=", now));
+    constraints.push(where("fechaVencimiento", "<=", future));
+    orderField = "fechaVencimiento";
+    orderDir = "asc";
+  }
+
+  if (f.status === "activas") {
+    constraints.push(where("fechaVencimiento", ">=", Timestamp.now()));
+    constraints.push(where("activa", "==", true));
+    orderField = "fechaVencimiento";
+    orderDir = "asc";
+  } else if (f.status === "vencidas") {
+    constraints.push(where("fechaVencimiento", "<", Timestamp.now()));
+    orderField = "fechaVencimiento";
+    orderDir = "asc";
+  }
+
+  constraints.push(orderBy(orderField, orderDir));
+  const pageLimit = f.limit ?? 10;
+  constraints.push(limitQuery(pageLimit));
+
+  if (f.startAfterId) {
+    const cursorSnap = await getDoc(doc(db, COL, f.startAfterId));
+    if (cursorSnap.exists()) constraints.push(startAfter(cursorSnap));
+  }
+
+  const q = query(collection(db, COL), ...constraints);
+  const snap = await getDocs(q);
+  const items = snap.docs.map((d) => ({ id: d.id, ...(d.data() as Empresa) }));
+
+  const last = snap.docs[snap.docs.length - 1];
+  const nextPageCursor = snap.docs.length === pageLimit ? last?.id : undefined;
+
+  return { items, nextPageCursor };
+}
+
+export async function createEmpresa(
+  data: Omit<Empresa, "id" | "actualizadoEn">,
+  actor: Usuario
+): Promise<string> {
+  assertAdminOrMod(actor);
+  const colRef = collection(db, COL);
+  const docRef = await addDoc(colRef, {
+    ...data,
+    actualizadoEn: serverTimestamp(),
+  });
+  return docRef.id;
+}
+
+export async function updateEmpresa(
+  id: string,
+  data: Partial<Empresa>,
+  actor: Usuario
+): Promise<void> {
+  assertAdminOrMod(actor);
+  if (data.fechaAlta && !(data.fechaAlta instanceof Timestamp)) {
+    throw new Error("fechaAlta debe ser Timestamp");
+  }
+  if (data.fechaVencimiento && !(data.fechaVencimiento instanceof Timestamp)) {
+    throw new Error("fechaVencimiento debe ser Timestamp");
+  }
+  const ref = doc(db, COL, id);
+  await updateDoc(ref, { ...data, actualizadoEn: serverTimestamp() });
+}
+
+export async function deleteEmpresa(
+  id: string,
+  actor: Usuario
+): Promise<void> {
+  assertAdmin(actor);
+  await deleteDoc(doc(db, COL, id));
+}

--- a/src/services/usuarios.ts
+++ b/src/services/usuarios.ts
@@ -1,0 +1,102 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit as limitQuery,
+  startAfter,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  serverTimestamp,
+  QueryConstraint,
+} from "firebase/firestore";
+import { db } from "../lib/firebase";
+import type { Usuario } from "../types";
+
+const COL = "Usuarios";
+
+const assertAdminOrMod = (actor: Usuario) => {
+  if (actor.rol !== "Administrador" && actor.rol !== "Moderador") {
+    throw new Error("No autorizado");
+  }
+};
+
+const assertAdmin = (actor: Usuario) => {
+  if (actor.rol !== "Administrador") {
+    throw new Error("No autorizado");
+  }
+};
+
+export async function getPerfilByEmail(email: string): Promise<Usuario | null> {
+  const snap = await getDoc(doc(db, COL, email));
+  return snap.exists() ? (snap.data() as Usuario) : null;
+}
+
+export async function listUsuarios(opts?: {
+  rol?: Usuario["rol"];
+  facultad?: string;
+  activo?: boolean;
+  limit?: number;
+  startAfterId?: string;
+}): Promise<{ items: Usuario[]; nextPageCursor?: string }> {
+  const constraints: QueryConstraint[] = [];
+  if (opts?.rol) constraints.push(where("rol", "==", opts.rol));
+  if (opts?.facultad) constraints.push(where("facultad", "==", opts.facultad));
+  if (opts?.activo !== undefined) constraints.push(where("activo", "==", opts.activo));
+
+  constraints.push(orderBy("email"));
+  const pageLimit = opts?.limit ?? 10;
+  constraints.push(limitQuery(pageLimit));
+
+  if (opts?.startAfterId) {
+    const cursorSnap = await getDoc(doc(db, COL, opts.startAfterId));
+    if (cursorSnap.exists()) constraints.push(startAfter(cursorSnap));
+  }
+
+  const q = query(collection(db, COL), ...constraints);
+  const snap = await getDocs(q);
+  const items = snap.docs.map((d) => ({
+    ...(d.data() as Usuario),
+    email: d.id,
+  }));
+
+  const last = snap.docs[snap.docs.length - 1];
+  const nextPageCursor = snap.docs.length === pageLimit ? last?.id : undefined;
+
+  return { items, nextPageCursor };
+}
+
+export async function createUsuario(
+  data: Usuario,
+  actor: Usuario
+): Promise<void> {
+  assertAdminOrMod(actor);
+  const ref = doc(db, COL, data.email);
+  await setDoc(ref, {
+    ...data,
+    creadoEn: serverTimestamp(),
+    actualizadoEn: serverTimestamp(),
+  });
+}
+
+export async function updateUsuario(
+  email: string,
+  data: Partial<Usuario>,
+  actor: Usuario
+): Promise<void> {
+  assertAdminOrMod(actor);
+  const ref = doc(db, COL, email);
+  await updateDoc(ref, { ...data, actualizadoEn: serverTimestamp() });
+}
+
+export async function deleteUsuario(
+  email: string,
+  actor: Usuario
+): Promise<void> {
+  assertAdmin(actor);
+  await deleteDoc(doc(db, COL, email));
+}

--- a/src/services/vacantes.ts
+++ b/src/services/vacantes.ts
@@ -1,0 +1,114 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit as limitQuery,
+  startAfter,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  serverTimestamp,
+  Timestamp,
+  QueryConstraint,
+} from "firebase/firestore";
+import { db } from "../lib/firebase";
+import type { Vacante, FiltrosVacantes, Usuario } from "../types";
+
+const COL = "Vacantes";
+
+const assertAdminOrMod = (actor: Usuario) => {
+  if (actor.rol !== "Administrador" && actor.rol !== "Moderador") {
+    throw new Error("No autorizado");
+  }
+};
+
+const assertAdmin = (actor: Usuario) => {
+  if (actor.rol !== "Administrador") {
+    throw new Error("No autorizado");
+  }
+};
+
+export async function listVacantes(
+  f: FiltrosVacantes & { limit?: number; startAfterId?: string }
+): Promise<{ items: Vacante[]; nextPageCursor?: string }> {
+  const constraints: QueryConstraint[] = [];
+  if (f.facultad) constraints.push(where("facultad", "==", f.facultad));
+  if (f.estado) constraints.push(where("estado", "==", f.estado));
+  if (f.rangoAlta?.desde)
+    constraints.push(where("fechaAlta", ">=", f.rangoAlta.desde));
+  if (f.rangoAlta?.hasta)
+    constraints.push(where("fechaAlta", "<=", f.rangoAlta.hasta));
+
+  let orderField: string = "fechaAlta";
+  let orderDir: "asc" | "desc" = "desc";
+
+  if (f.proximasVencerDias !== undefined) {
+    const now = Timestamp.now();
+    const future = Timestamp.fromMillis(
+      now.toMillis() + f.proximasVencerDias * 86400000
+    );
+    constraints.push(where("fechaVencimiento", ">=", now));
+    constraints.push(where("fechaVencimiento", "<=", future));
+    orderField = "fechaVencimiento";
+    orderDir = "asc";
+  }
+
+  constraints.push(orderBy(orderField, orderDir));
+  const pageLimit = f.limit ?? 10;
+  constraints.push(limitQuery(pageLimit));
+
+  if (f.startAfterId) {
+    const cursorSnap = await getDoc(doc(db, COL, f.startAfterId));
+    if (cursorSnap.exists()) constraints.push(startAfter(cursorSnap));
+  }
+
+  const q = query(collection(db, COL), ...constraints);
+  const snap = await getDocs(q);
+  const items = snap.docs.map((d) => ({ id: d.id, ...(d.data() as Vacante) }));
+
+  const last = snap.docs[snap.docs.length - 1];
+  const nextPageCursor = snap.docs.length === pageLimit ? last?.id : undefined;
+
+  return { items, nextPageCursor };
+}
+
+export async function createVacante(
+  data: Omit<Vacante, "id" | "actualizadoEn">,
+  actor: Usuario
+): Promise<string> {
+  assertAdminOrMod(actor);
+  const colRef = collection(db, COL);
+  const docRef = await addDoc(colRef, {
+    ...data,
+    actualizadoEn: serverTimestamp(),
+  });
+  return docRef.id;
+}
+
+export async function updateVacante(
+  id: string,
+  data: Partial<Vacante>,
+  actor: Usuario
+): Promise<void> {
+  assertAdminOrMod(actor);
+  if (data.fechaAlta && !(data.fechaAlta instanceof Timestamp)) {
+    throw new Error("fechaAlta debe ser Timestamp");
+  }
+  if (data.fechaVencimiento && !(data.fechaVencimiento instanceof Timestamp)) {
+    throw new Error("fechaVencimiento debe ser Timestamp");
+  }
+  const ref = doc(db, COL, id);
+  await updateDoc(ref, { ...data, actualizadoEn: serverTimestamp() });
+}
+
+export async function deleteVacante(
+  id: string,
+  actor: Usuario
+): Promise<void> {
+  assertAdmin(actor);
+  await deleteDoc(doc(db, COL, id));
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,60 @@
+import type { Timestamp, DocumentReference } from "firebase/firestore";
+
+export interface Usuario {
+  email: string;
+  nombre: string;
+  rol: "Administrador" | "Moderador" | "Usuario";
+  facultad: string;
+  activo: boolean;
+  creadoEn?: Timestamp;
+  actualizadoEn?: Timestamp;
+}
+
+export interface Empresa {
+  id?: string;
+  nombre: string;
+  rfc?: string;
+  facultad: string;
+  activa: boolean;
+  fechaAlta: Timestamp;
+  fechaVencimiento?: Timestamp;
+  creadoPor?: string;
+  actualizadoEn?: Timestamp;
+}
+
+export interface Vacante {
+  id?: string;
+  empresaRef: DocumentReference;
+  facultad: string;
+  titulo: string;
+  descripcion: string;
+  fechaAlta: Timestamp;
+  fechaVencimiento: Timestamp;
+  estado: "activa" | "vencida" | "cerrada";
+  plazas: number;
+  contrataciones: {
+    total: number;
+    uas: number;
+  };
+  creadoPor?: string;
+  actualizadoEn?: Timestamp;
+}
+
+export type RangoFechas = {
+  desde?: Timestamp;
+  hasta?: Timestamp;
+};
+
+export type FiltrosEmpresas = {
+  facultad?: string;
+  rangoAlta?: RangoFechas;
+  proximasVencerDias?: number;
+  status?: "activas" | "vencidas";
+};
+
+export type FiltrosVacantes = {
+  facultad?: string;
+  estado?: "activa" | "vencida" | "cerrada";
+  rangoAlta?: RangoFechas;
+  proximasVencerDias?: number;
+};


### PR DESCRIPTION
## Summary
- define interfaces and filter types for usuarios, empresas y vacantes
- implement Firestore services with filters, pagination and role checks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt)

------
https://chatgpt.com/codex/tasks/task_e_68af7a1b0170832b881c6c29adab7a1a