### PR TITLE
Add Firestore security rules and indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,30 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "Vacantes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "facultad", "order": "ASCENDING" },
+        { "fieldPath": "estado", "order": "ASCENDING" },
+        { "fieldPath": "fechaVencimiento", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "Vacantes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "facultad", "order": "ASCENDING" },
+        { "fieldPath": "fechaAlta", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "Empresas",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "facultad", "order": "ASCENDING" },
+        { "fieldPath": "fechaVencimiento", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,47 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function signedIn() {
+      return request.auth != null;
+    }
+    function userEmail() {
+      return request.auth.token.email;
+    }
+    function userDoc() {
+      return get(/databases/$(database)/documents/Usuarios/$(userEmail()));
+    }
+    function isActive() {
+      return userDoc().data != null && userDoc().data.activo == true;
+    }
+    function hasRole(role) {
+      return userDoc().data != null && userDoc().data.rol == role;
+    }
+    function isAdmin() {
+      return hasRole("Administrador");
+    }
+    function isMod() {
+      return hasRole("Moderador");
+    }
+    function isUser() {
+      return hasRole("Usuario");
+    }
+
+    match /Empresas/{empresaId} {
+      allow read: if resource.data.activa == true || (signedIn() && isActive());
+      allow create, update: if signedIn() && isActive() && (isAdmin() || isMod());
+      allow delete: if signedIn() && isActive() && isAdmin();
+    }
+
+    match /Vacantes/{vacanteId} {
+      allow read, create, update: if signedIn() && isActive() && (isAdmin() || isMod());
+      allow delete: if signedIn() && isActive() && isAdmin();
+    }
+
+    match /Usuarios/{userId} {
+      allow get: if signedIn() && isActive() && (userEmail() == userId || isAdmin() || isMod());
+      allow list: if signedIn() && isActive() && (isAdmin() || isMod());
+      allow create, update: if signedIn() && isActive() && (isAdmin() || isMod());
+      allow delete: if signedIn() && isActive() && isAdmin();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules with role-based access for Empresas, Vacantes, and Usuarios
- define helper functions for authentication and role checks
- configure composite Firestore indexes for Vacantes and Empresas queries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af9140d8c4832ba2b8d4fed85c4bfe