### PR TITLE
feat: add dashboard layout with role-based sidebar

### DIFF
--- a/app/(protected)/dashboard/components/Sidebar.tsx
+++ b/app/(protected)/dashboard/components/Sidebar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import clsx from "clsx";
+
+export type Rol = "Administrador" | "Moderador" | "Usuario";
+
+export default function Sidebar({ rol }: { rol: Rol }) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  const links =
+    rol === "Administrador" || rol === "Moderador"
+      ? [
+          { label: "Usuarios", href: "/dashboard/usuarios" },
+          { label: "Vacantes", href: "/dashboard/vacantes" },
+          { label: "Empresas", href: "/dashboard/empresas" },
+          { label: "Reportes", href: "/dashboard/reportes" },
+        ]
+      : [
+          { label: "Vacantes", href: "/dashboard/vacantes" },
+          { label: "Empresas", href: "/dashboard/empresas" },
+          { label: "Reportes", href: "/dashboard/reportes" },
+        ];
+
+  return (
+    <>
+      <button
+        className="fixed left-4 top-4 z-30 rounded-md border bg-white p-2 text-green-700 shadow md:hidden"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Abrir menú"
+      >
+        <svg
+          className="h-6 w-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 6h16M4 12h16M4 18h16"
+          />
+        </svg>
+      </button>
+
+      <aside
+        className={clsx(
+          "fixed inset-y-0 left-0 z-20 w-64 border-r bg-white shadow transition-transform md:translate-x-0",
+          open ? "translate-x-0" : "-translate-x-full",
+          "md:static md:block"
+        )}
+      >
+        <div className="border-b p-4 text-center text-2xl font-bold text-green-700">
+          VACANTES UAS
+        </div>
+        <nav className="space-y-1 p-4">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              onClick={() => setOpen(false)}
+              className={clsx(
+                "block rounded-md px-3 py-2 text-sm font-medium hover:bg-green-50",
+                pathname.startsWith(link.href)
+                  ? "bg-green-100 text-green-700"
+                  : "text-gray-700"
+              )}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import Sidebar from "./components/Sidebar";
+import { useAuth } from "../../../src/context/AuthContext";
+import type { Rol } from "./components/Sidebar";
+
+export default function DashboardPage() {
+  const { user, perfil, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900" />
+      </div>
+    );
+  }
+
+  const rol = (perfil?.rol as Rol) || "Usuario";
+  const greetingName =
+    (perfil as any)?.nombre ?? user?.displayName ?? "Usuario";
+
+  const links =
+    rol === "Administrador" || rol === "Moderador"
+      ? [
+          { title: "Usuarios", href: "/dashboard/usuarios" },
+          { title: "Vacantes", href: "/dashboard/vacantes" },
+          { title: "Empresas", href: "/dashboard/empresas" },
+          { title: "Reportes", href: "/dashboard/reportes" },
+        ]
+      : [
+          { title: "Vacantes", href: "/dashboard/vacantes" },
+          { title: "Empresas", href: "/dashboard/empresas" },
+          { title: "Reportes", href: "/dashboard/reportes" },
+        ];
+
+  return (
+    <div className="flex min-h-screen bg-gray-50">
+      <Sidebar rol={rol} />
+      <main className="flex-1 p-4 md:ml-64">
+        <h1 className="mb-6 text-2xl font-semibold text-green-800">
+          Hola, {greetingName}
+          {perfil?.facultad ? ` · ${perfil.facultad}` : ""}
+        </h1>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {links.map((link) => (
+            <Link key={link.href} href={link.href} className="block">
+              <div className="rounded-lg border border-green-200 bg-white p-6 shadow-sm transition hover:bg-green-50 hover:shadow">
+                <h2 className="text-lg font-medium text-green-700">{link.title}</h2>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement role-aware sidebar with mobile toggle for dashboard
- create dashboard page showing greeting and role-specific navigation cards

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68af9223f9f8832b9c7495d2154be141