### PR TITLE
Guard against auth hook misuse

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import type { ReactNode } from "react";
+import { AuthProvider } from "../src/context/AuthContext";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -13,7 +14,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="es" suppressHydrationWarning>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -24,9 +24,13 @@ type AuthContextProps = {
   signOutApp: () => Promise<void>;
 };
 
-const AuthContext = createContext<AuthContextProps>(null as any);
+const AuthContext = createContext<AuthContextProps | null>(null);
 
-export const useAuth = () => useContext(AuthContext);
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within <AuthProvider>");
+  return ctx;
+};
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);


### PR DESCRIPTION
## Summary
- Ensure useAuth throws when used outside of AuthProvider
- Wrap entire app with AuthProvider so all components consume context correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b0881fac88832b963d889f9b20ce94