### PR TITLE
Allow users to read their profile without active status

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,7 +8,10 @@ service cloud.firestore {
       return request.auth.token.email;
     }
     function userDoc() {
-      return get(/databases/$(database)/documents/Usuarios/$(userEmail()));
+      return resource != null && resource.__name__ ==
+        /databases/$(database)/documents/Usuarios/$(userEmail())
+        ? resource
+        : get(/databases/$(database)/documents/Usuarios/$(userEmail()));
     }
     function isActive() {
       return userDoc().data != null && userDoc().data.activo == true;
@@ -38,7 +41,9 @@ service cloud.firestore {
     }
 
     match /Usuarios/{userId} {
-      allow get: if signedIn() && isActive() && (userEmail() == userId || isAdmin() || isMod());
+      allow get: if signedIn() &&
+        (userEmail() == userId ||
+          (isActive() && (isAdmin() || isMod())));
       allow list: if signedIn() && isActive() && (isAdmin() || isMod());
       allow create, update: if signedIn() && isActive() && (isAdmin() || isMod());
       allow delete: if signedIn() && isActive() && isAdmin();


### PR DESCRIPTION
## Summary
- Allow signed-in users to read their own `Usuarios` document without needing to be active
- Use `resource` to access a user's profile inside rules to avoid recursive reads

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `firebase deploy --only firestore:rules` *(fails: firebase command not found; attempted npx install but process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cf72fca4832bab928039e34e87c8