### PR TITLE
Handle verification errors in AuthContext

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -51,17 +51,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
     const ref = doc(db, "Usuarios", u.email);
-    const snap = await getDoc(ref);
-    if (!snap.exists() || !snap.data().activo) {
+    try {
+      const snap = await getDoc(ref);
+      if (!snap.exists() || !snap.data().activo) {
+        await signOut(auth);
+        clearSession();
+        alert("No autorizado, contacta al administrador");
+        return;
+      }
+      const data = snap.data() as Perfil;
+      setUser(u);
+      setPerfil(data);
+      document.cookie = `session=${u.email}; path=/`;
+    } catch (error) {
       await signOut(auth);
       clearSession();
-      alert("No autorizado, contacta al administrador");
-      return;
+      alert("Error verificando al usuario, intenta de nuevo");
     }
-    const data = snap.data() as Perfil;
-    setUser(u);
-    setPerfil(data);
-    document.cookie = `session=${u.email}; path=/`;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Wrap user verification lookup in try/catch
- Sign out and display message if verification fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b0e1132078832b9cf37e532e1420bd