### PR TITLE
fix: verify users using email field

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/services/usuarios.ts
+++ b/src/services/usuarios.ts
@@ -32,14 +32,15 @@ const assertAdmin = (actor: Usuario) => {
 };
 
 export async function getPerfilByEmail(email: string): Promise<Usuario | null> {
-  const ref = doc(db, COL, email);
-  const snap = await getDoc(ref);
-  if (snap.exists()) return snap.data() as Usuario;
-
-  const q = query(collection(db, COL), where("email", "==", email), limitQuery(1));
+  const q = query(
+    collection(db, COL),
+    where("email", "==", email),
+    limitQuery(1)
+  );
   const qsnap = await getDocs(q);
   if (!qsnap.empty) {
-    return qsnap.docs[0].data() as Usuario;
+    const docSnap = qsnap.docs[0];
+    return { ...(docSnap.data() as Usuario) };
   }
   return null;
 }
@@ -67,10 +68,7 @@ export async function listUsuarios(opts?: {
 
   const q = query(collection(db, COL), ...constraints);
   const snap = await getDocs(q);
-  const items = snap.docs.map((d) => ({
-    ...(d.data() as Usuario),
-    email: d.id,
-  }));
+  const items = snap.docs.map((d) => d.data() as Usuario);
 
   const last = snap.docs[snap.docs.length - 1];
   const nextPageCursor = snap.docs.length === pageLimit ? last?.id : undefined;


### PR DESCRIPTION
## Summary
- query Users collection using email field for profile lookup
- simplify user listing to rely on stored email field

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires configuration)


------
https://chatgpt.com/codex/tasks/task_e_68b5de519a1c832ba14655dd3e5d312a