### PR TITLE
fix: fetch user profile without Firestore query

### DIFF
--- a/src/services/usuarios.ts
+++ b/src/services/usuarios.ts
@@ -32,15 +32,10 @@ const assertAdmin = (actor: Usuario) => {
 };
 
 export async function getPerfilByEmail(email: string): Promise<Usuario | null> {
-  const q = query(
-    collection(db, COL),
-    where("email", "==", email),
-    limitQuery(1)
-  );
-  const qsnap = await getDocs(q);
-  if (!qsnap.empty) {
-    const docSnap = qsnap.docs[0];
-    return { ...(docSnap.data() as Usuario) };
+  const ref = doc(db, COL, email);
+  const snap = await getDoc(ref);
+  if (snap.exists()) {
+    return { ...(snap.data() as Usuario) };
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- lookup user profile with direct document read to avoid Firestore query restrictions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5ccaadc832b85a510961002b661